### PR TITLE
Shortened GUID prefixes to avoid the following warnings when validating ...

### DIFF
--- a/Paraffin/Main.cs
+++ b/Paraffin/Main.cs
@@ -754,7 +754,7 @@ namespace Wintellect.Paraffin
             Guid g = Guid.NewGuid();
             String guidString = g.ToString("N").ToUpperInvariant();
             return String.Format(CultureInfo.InvariantCulture,
-                                    "dir_{0}",
+                                    "d_{0}",
                                     guidString);
         }
 
@@ -807,7 +807,7 @@ namespace Wintellect.Paraffin
             {
                 Guid g = Guid.NewGuid();
                 fileId = String.Format(CultureInfo.InvariantCulture,
-                                       "file_{0}",
+                                       "f_{0}",
                          g.ToString("N").ToUpper(CultureInfo.InvariantCulture));
             }
 
@@ -849,7 +849,7 @@ namespace Wintellect.Paraffin
             {
                 Guid g = Guid.NewGuid();
                 componentId = String.Format(CultureInfo.InvariantCulture,
-                                            "comp_{0}",
+                                            "c_{0}",
                  g.ToString("N").ToUpper(CultureInfo.InvariantCulture));
             }
 


### PR DESCRIPTION
...with Orca:

   ICE03 Warnings: String overflow (greater than length permitted in column)

"The Identifier data type is a text string. Identifiers may contain the ASCII characters A-Z (a-z), digits, underscores (_), or periods (.). However, every identifier must begin with either a letter or an underscore."

http://msdn.microsoft.com/en-us/library/aa369212(v=vs.85).aspx

The identifier allows a maximum of 72 characters, which seems undocumented. This limitation is met when creating merge modules out of fragments produced with Paraffin.